### PR TITLE
Shift bits left and move the 24 color bits left too

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,12 +33,13 @@ class NeoPixel {
       pullThreshold: 24,
       fifoJoin: PIO.FIFO_JOIN_TX,
       sidesetBase: this.pin,
+      outShiftDir: PIO.SHIFT_LEFT,
     });
     this.sm.active(true);
   }
 
   color(r, g, b) {
-    return (b << 16) | (r << 8) | g;
+    return (g << 24) | (r << 16) | (b << 8);
   }
 
   setPixel(index, color) {


### PR DESCRIPTION
Brightness seemed to be off: 0 and 255 worked fine, but anything between appeared random. Looking at MicroPython gave me the hint: they move bits LEFT while the default is right. And then it clicked.  Now the bits are in the right order.